### PR TITLE
Fixing future time calculation.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
     <div class="abstract-header">
       {{ page.speaker }}<br>
       {{ page.date | date: "%B %-d, %Y"}}<br>
-      {% assign curDate = site.time | date: '%s' | minus: 46800 | date: '%s' %}
+      {% assign curDate = site.time | date: '%s' | minus: 86400 | date: '%s' %}
       {% assign startDate = page.date | date: '%s' %}
       {% if startDate >= curDate %}
         {% if page.time %}{{ page.time }}<br>{% endif %}

--- a/seminars.html
+++ b/seminars.html
@@ -9,7 +9,7 @@ layout: default
   </p>
   <h1 style="margin-left:-50pt">Upcoming Seminars</h1>
   <table id="seminar-schedule"  style="margin-bottom:20pt">
-    {% assign curDate = site.time | date: '%s' | minus: 46800 | date:'%s' %}
+    {% assign curDate = site.time | date: '%s' | minus: 86400 | date:'%s' %}
     {% for post in site.seminars %}
     {% assign postStartDate = post.date | date: '%s' %}
     {% if postStartDate >= curDate%}


### PR DESCRIPTION
It looks like future time calculation depends on the server's timezone setting, causes different behavior on local machine vs. host. We need to do this calculation in a timezone-invariant way, but for now just adding a bigger buffer to what constitutes a future date.